### PR TITLE
Feature/cadastrar lote validade para tras

### DIFF
--- a/src/api/routes/lotes.py
+++ b/src/api/routes/lotes.py
@@ -13,7 +13,11 @@ lote_bp = Blueprint('lotes', __name__, url_prefix='/lotes')
 def cadastrar_lote():
     data = request.get_json()
 
-    validade = datetime.strptime(data['data_validade'], "%Y-%m-%d")
+    validade = datetime.strptime(data['data_validade'], "%Y-%m-%d").date()
+    data_atual = datetime.now().date()
+
+    if validade <= data_atual:
+        return jsonify({'error': 'Data de validade inválida'}), 404
 
     newLote = Lote(
         num_lote = data['num_lote'],

--- a/src/front-end/js/estoque-js.js
+++ b/src/front-end/js/estoque-js.js
@@ -355,7 +355,6 @@ function cadastrarLote(event) {
 
   // Cria o novo lote
   const novoLote = {
-    id: nextLoteId++,
     num_lote: numLote,
     data_validade: dataValidade,
     fabricante: fabricante,
@@ -403,17 +402,28 @@ function cadastrarLote(event) {
     }),
   })
     .then((response) => {
+      if (response.status === 404) {
+        return response.json().then((data) => {
+          throw new Error("Data de validade inválida");        
+        });
+      }
+      if (!response.ok) {
+        return response.json().then((data) => {
+          throw new Error(data.error || "Erro desconhecido");
+        });
+      }
       alert("Medicamento cadastrado com sucesso");
-      // Redireciona para a página de estoque
       setTimeout(function () {
         window.location.href = "/estoque";
       }, 500);
-      return response.json(); // Continuar com o processamento normal da resposta se não for 422
+  
+      return response.json();
     })
     .catch((error) => {
       console.error("Erro:", error);
-      alert(error);
+      alert(`Erro: ${error.message}`);
     });
+  
 }
 
 // Função para cadastrar um novo medicamento


### PR DESCRIPTION
## 📌 Descrição
Esse pull request implementa a lógica para cadastrar lote validando a data de validade para não ser possivel criar lote para trás e no front adiciona um alert ao tentar criar o lote com data de validade errada

